### PR TITLE
fix: update PostgreSQL version to 15.12 to resolve deployment conflict

### DIFF
--- a/infrastructure/terraform/environments/dev/terraform.tfvars
+++ b/infrastructure/terraform/environments/dev/terraform.tfvars
@@ -20,7 +20,7 @@ storage_cloudfront_price_class     = "PriceClass_100"
 storage_cors_allowed_origins       = ["*"]
 
 # Database Configuration (Development Optimized)
-postgres_version                   = "15.8"
+postgres_version                   = "15.12"
 postgres_instance_class           = "db.t3.micro"      # ~$12/month
 postgres_allocated_storage        = 20                 # Minimum for gp2
 postgres_max_allocated_storage    = 100

--- a/infrastructure/terraform/environments/dev/terraform.tfvars.example
+++ b/infrastructure/terraform/environments/dev/terraform.tfvars.example
@@ -20,7 +20,7 @@ storage_cloudfront_price_class     = "PriceClass_100"
 storage_cors_allowed_origins       = ["*"]
 
 # Database Configuration (Development Optimized)
-postgres_version                   = "15.4"
+postgres_version                   = "15.12"
 postgres_instance_class           = "db.t3.micro"      # ~$12/month
 postgres_allocated_storage        = 20                 # Minimum for gp2
 postgres_max_allocated_storage    = 100

--- a/infrastructure/terraform/environments/dev/variables.tf
+++ b/infrastructure/terraform/environments/dev/variables.tf
@@ -79,7 +79,7 @@ variable "storage_cors_allowed_origins" {
 variable "postgres_version" {
   description = "PostgreSQL version"
   type        = string
-  default     = "15.4"
+  default     = "15.12"
 }
 
 variable "postgres_instance_class" {

--- a/infrastructure/terraform/modules/database/variables.tf
+++ b/infrastructure/terraform/modules/database/variables.tf
@@ -30,7 +30,7 @@ variable "redis_security_group_id" {
 variable "postgres_version" {
   description = "PostgreSQL engine version"
   type        = string
-  default     = "15.4"
+  default     = "15.12"
 }
 
 variable "postgres_instance_class" {


### PR DESCRIPTION
- Update postgres_version from 15.8/15.4 to 15.12 in terraform.tfvars and variables.tf
- Resolves AWS RDS deployment error: Cannot upgrade postgres from 15.12 to 15.8
- Aligns Terraform configuration with existing RDS instance version (15.12)
- Prevents PostgreSQL downgrade attempts during infrastructure deployment

Updated files:
- infrastructure/terraform/environments/dev/terraform.tfvars
- infrastructure/terraform/environments/dev/variables.tf
- infrastructure/terraform/modules/database/variables.tf

🤖 Generated with [Claude Code](https://claude.ai/code)